### PR TITLE
Add big number exception handling, off-by-one in Int/Long handling (not serious), and version bump

### DIFF
--- a/fastb.c
+++ b/fastb.c
@@ -235,9 +235,10 @@ _fastb_read_pyobj_long(FILE *stream, PyObject *fallback) {
 static int
 _fastb_write_pyobj_long(FILE *stream, PyObject *pyobj, PyObject *fallback) {
   long long l = PyLong_AsLongLong(pyobj);
-  if (-9223372036854775807LL <= l && l <= 9223372036854775807LL) {
+  if (!PyErr_Occurred() && -9223372036854775807LL <= l && l <= 9223372036854775807LL) {
     return _fastb_write_long(stream, l);
   } else {
+    PyErr_Clear();
     return _fastb_write_pyobj_fallback(stream, pyobj, fallback);
   }
 }

--- a/fastb.c
+++ b/fastb.c
@@ -220,7 +220,7 @@ _fastb_read_pyobj_int(FILE *stream, PyObject *fallback) {
 static int 
 _fastb_write_pyobj_int(FILE *stream, PyObject *pyobj, PyObject *fallback) {
   long l = PyInt_AS_LONG(pyobj);
-  if (-2147483647L <= l && l <= 2147483647L) {
+  if (-2147483648L <= l && l <= 2147483647L) {
     return _fastb_write_int(stream, l);
   } else {
     return _fastb_write_long(stream, l);
@@ -235,7 +235,7 @@ _fastb_read_pyobj_long(FILE *stream, PyObject *fallback) {
 static int
 _fastb_write_pyobj_long(FILE *stream, PyObject *pyobj, PyObject *fallback) {
   long long l = PyLong_AsLongLong(pyobj);
-  if (!PyErr_Occurred() && -9223372036854775807LL <= l && l <= 9223372036854775807LL) {
+  if (!PyErr_Occurred() && -9223372036854775808LL <= l && l <= 9223372036854775807LL) {
     return _fastb_write_long(stream, l);
   } else {
     PyErr_Clear();

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, Extension
 setup(name='ctypedbytes',
-      version='0.1.7',
+      version='0.1.8',
       description='A fast Python module for dealing with so called "typed bytes"',
       author='Klaas Bosteels',
       author_email='klaas@last.fm',


### PR DESCRIPTION
1. Big number exception handling (previous didn't support anything outside of [-2**63, 2**63-1])
2. Off-by-one in Int/Long handling.  This is not serious, one number in each range would have been a pickle instead of an integer type; however, it's good to have it be clear what ranges become pickles and what ranges become native ints
3. Version bump
