### PR TITLE
Fix error caused by missing StructError import

### DIFF
--- a/ctypedbytes.py
+++ b/ctypedbytes.py
@@ -19,6 +19,7 @@ def classes():
     import sys
     import typedbytes
     from fastb import reads, writes
+    from struct import error as StructError
 
     
     def flatten(iterable):

--- a/tests/testio.py
+++ b/tests/testio.py
@@ -3,7 +3,7 @@ import unittest
 import decimal
 import datetime
 import ctypedbytes as typedbytes
-
+from struct import error as StructError
 
 class TestIO(unittest.TestCase):
 
@@ -24,6 +24,20 @@ class TestIO(unittest.TestCase):
             self.assertEqual(objects[index], record)
         file.close()
         os.remove("test.bin")
+
+    def testwrongio(self):
+        try:
+            file = open("test.bin", "wb")
+            output = typedbytes.Output(file)
+            output.writes([1])
+            file.close()
+            file = open("test.bin", "rb")
+            input = typedbytes.Input(file)
+            input = typedbytes.PairedInput(file)
+            self.assertRaises(StructError, lambda :list(input.reads()))
+            file.close()
+        finally:
+            os.remove("test.bin")
 
     def testpairio(self):
         objects = TestIO.objects


### PR DESCRIPTION
Hi, if your input file is somehow corrupted, ctypedbytes will fail to raise the right exception (StructError) because it is missing an import.
